### PR TITLE
[Config] Adding run-script-os to be able to run the project in windows and mac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "client"
       ],
       "devDependencies": {
-        "concurrently": "^9.1.2"
+        "concurrently": "^9.1.2",
+        "run-script-os": "^1.1.6"
       },
       "engines": {
         "node": ">=18.18.0"
@@ -9106,6 +9107,16 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true,
+      "bin": {
+        "run-os": "index.js",
+        "run-script-os": "index.js"
       }
     },
     "node_modules/rxjs": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
     "lint": "concurrently -n \"client,server\" -c \"bgMagenta\" \"npm run lint:client\" ",
     "lint:server": "cd server && npm run lint",
     "lint:client": "cd client && npm run lint",
-    "dev": "npm i && concurrently -n \"client,server\" -c \"bgMagenta,cyan\" \"npm run dev:client\" \"npm run dev:server\"",
-    "dev:client": "cd client && npm i && export NEXT_PUBLIC_API_URL=http://localhost:3200 && npm run dev",
+    "dev": "run-script-os",
+    "dev:macos": "npm i && concurrently -n \"client,server\" -c \"bgMagenta,cyan\" \"npm run dev:client:macos\" \"npm run dev:server\"",
+    "dev:windows": "npm i && concurrently -n \"client,server\" -c \"bgMagenta,cyan\" \"npm run dev:client:windows\" \"npm run dev:server\"",
+    "dev:client:macos": "cd client && npm i && export NEXT_PUBLIC_API_URL=http://localhost:3200 && npm run dev",
+    "dev:client:windows": "cd client && npm i && set NEXT_PUBLIC_API_URL=http://localhost:3200 && npm run dev",
     "dev:server": "cd server && npm i && npm run dev",
     "start": "concurrently -n \"client,server\" -c \"bgMagenta,bgCyan\" \"npm run start:client\" \"npm run start:server\"",
     "start:client": "cd client && npm i && npm run start",
@@ -37,6 +40,7 @@
   "homepage": "https://github.com/hectormosq/plenify#readme",
   "description": "",
   "devDependencies": {
-    "concurrently": "^9.1.2"
+    "concurrently": "^9.1.2",
+    "run-script-os": "^1.1.6"
   }
 }


### PR DESCRIPTION
This PR aims to allow mac and windows users to be able to execute the project locally.

After this change you will only need to execute
```
npm run dev
```
and the new script will take care of the OS intrinsics .